### PR TITLE
Adds {proxy+} support in local lambdas

### DIFF
--- a/src/express/utils/create-lambda-request-handler.ts
+++ b/src/express/utils/create-lambda-request-handler.ts
@@ -32,7 +32,11 @@ export function createLambdaRequestHandler(
             path: req.path,
             httpMethod: req.method,
             queryStringParameters: req.query,
-            body: req.body ? JSON.stringify(req.body) : null
+            body: req.body
+              ? typeof req.body === 'string'
+                ? req.body
+                : JSON.stringify(req.body)
+              : null
           }
         }));
 

--- a/src/express/utils/create-lambda-request-handler.ts
+++ b/src/express/utils/create-lambda-request-handler.ts
@@ -30,8 +30,9 @@ export function createLambdaRequestHandler(
           event: {
             ...getRequestHeaders(req),
             path: req.path,
+            httpMethod: req.method,
             queryStringParameters: req.query,
-            body: req.body
+            body: req.body ? JSON.stringify(req.body) : null
           }
         }));
 

--- a/src/express/utils/serve-local-lambda.ts
+++ b/src/express/utils/serve-local-lambda.ts
@@ -10,8 +10,10 @@ export function serveLocalLambda(
 ): void {
   const {httpMethod, publicPath} = lambdaConfig;
 
+  const normalizedPublicPath = publicPath.replace('{proxy+}', '*');
+
   getRouterMatcher(app, httpMethod)(
-    publicPath,
+    normalizedPublicPath,
     createLambdaRequestHandler(lambdaConfig, useCache)
   );
 }


### PR DESCRIPTION
- Adds support for local dev server to support AWS Lambda Proxy Integrations in API Gateway.
  That Allows to set following configuration:
  ```
  lambdaConfigs: [
    {
      publicPath: '/bff/{proxy+}',
      httpMethod: 'ANY'
      ...
    }
  ]
  ```

- Adds some missing `APIGatewayProxyEvent` properties