### PR TITLE
Only set AWS_SDK_LOAD_CONFIG if config file exists

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -18,7 +18,7 @@ if (fs.existsSync(awsConfigFile) && !fs.existsSync(sharedCredentialsFile)) {
   fs.writeFileSync(sharedCredentialsFile, '');
 }
 
-if (fs.existsSync(sharedCredentialsFile)) {
+if (fs.existsSync(awsConfigFile)) {
   /*
    * Ensure that the AWS SDK will load region from ~/.aws/config
    * if the environment variable AWS_REGION is not set.


### PR DESCRIPTION
If a user has a `~/.aws` directory with only a `credentials` file and no `config` file in it, aws-simple will set `AWS_SDK_LOAD_CONFIG` which leads to an fs error in the aws-sdk when running `aws-simple start`.