### PR TITLE
Add missing dependency for winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "signal-exit": "^3.0.2",
     "source-map-support": "^0.5.13",
     "url-join": "^4.0.1",
+    "winston": "^3.2.1",
     "yargs": "^15.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Without declaring the dependency explicitly this can lead to errors if in a mono-repo another major version of winston is hoisted to the top.