### PR TITLE
Access-Control-Allow-Origin header for unauthorized response

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,9 @@ exports.default = {
       username: process.env.USERNAME,
       password: process.env.PASSWORD,
       cacheTtlInSeconds: 300,
+      unauthorizedResponseHeaders: {
+        accessControlAllowOrigin: '*',
+      },
     },
     lambdaConfigs: [
       {

--- a/src/cdk/utils/create-unauthorized-gateway-response.ts
+++ b/src/cdk/utils/create-unauthorized-gateway-response.ts
@@ -20,9 +20,11 @@ export function createUnauthorizedGatewayResponse(
   if (unauthorizedResponseHeaders) {
     const {accessControlAllowOrigin} = unauthorizedResponseHeaders;
 
-    responseParameters[
-      'gatewayresponse.header.Access-Control-Allow-Origin'
-    ] = `'${accessControlAllowOrigin}'`;
+    if (accessControlAllowOrigin) {
+      responseParameters[
+        'gatewayresponse.header.Access-Control-Allow-Origin'
+      ] = `'${accessControlAllowOrigin}'`;
+    }
   }
 
   // We need to use a low-level construct here that should be replaced when

--- a/src/cdk/utils/create-unauthorized-gateway-response.ts
+++ b/src/cdk/utils/create-unauthorized-gateway-response.ts
@@ -11,13 +11,27 @@ export function createUnauthorizedGatewayResponse(
     return;
   }
 
+  const responseParameters: Record<string, string> = {
+    'gatewayresponse.header.WWW-Authenticate': "'Basic'",
+  };
+
+  const {unauthorizedResponseHeaders} = stackConfig.basicAuthenticationConfig;
+
+  if (unauthorizedResponseHeaders) {
+    const {accessControlAllowOrigin} = unauthorizedResponseHeaders;
+
+    responseParameters[
+      'gatewayresponse.header.Access-Control-Allow-Origin'
+    ] = `'${accessControlAllowOrigin}'`;
+  }
+
   // We need to use a low-level construct here that should be replaced when
   // @aws-cdk/aws-apigateway adds a high-level construct for gateway responses.
   new CfnGatewayResponse(stack, 'ApiGatewayUnauthorizedResponse', {
     statusCode: '401',
     responseType: 'UNAUTHORIZED',
     restApiId: restApi.restApiId,
-    responseParameters: {'gatewayresponse.header.WWW-Authenticate': "'Basic'"},
+    responseParameters,
     responseTemplates: {
       'application/json': '{"message":$context.error.messageString}',
       'text/html': '$context.error.message',

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,10 +78,15 @@ export interface S3Config {
   readonly authenticationRequired?: boolean;
 }
 
+export interface UnauthorizedResponseHeaders {
+  readonly accessControlAllowOrigin?: string;
+}
+
 export interface BasicAuthenticationConfig {
   readonly username: string;
   readonly password: string;
   readonly cacheTtlInSeconds?: number;
+  readonly unauthorizedResponseHeaders?: UnauthorizedResponseHeaders;
 }
 
 export interface StackConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,6 +79,12 @@ export interface S3Config {
 }
 
 export interface UnauthorizedResponseHeaders {
+  /**
+   * Note: When an API with basic authentication is accessed cross-origin, it is
+   * important to define the origins that are allowed to access this API, even
+   * for the unauthorized response. Otherwise browsers will not be able display
+   * the dialog that prompts the credentials from the user.
+   */
   readonly accessControlAllowOrigin?: string;
 }
 


### PR DESCRIPTION
To be able to use an API with basic authentication enabled in a CORS setting, we need to set the `Access-Control-Allow-Origin` header on the `Unauthorized` response.