### PR TITLE
Introduce enableCors stack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,6 @@ exports.default = {
 
         // Optional example properties
         responseHeaders: {
-          accessControlAllowOrigin: '*',
           cacheControl: 'max-age=157680000',
         },
         cachingEnabled: true,
@@ -558,6 +557,23 @@ exports.default = {
 };
 ```
 
+### Enable CORS
+
+Basic CORS support can be enabled as follows:
+
+```js
+exports.default = {
+  appName: 'my-app',
+  appVersion: 'latest',
+  createStackConfig: () => ({
+    enableCors: true,
+  }),
+};
+```
+
+_Note: Additionally, Lambda handlers must explicitly set any required CORS
+headers like `Access-Control-Allow-Origin` on their response._
+
 ### Enable Basic Authentication
 
 You can configure basic authentication for an API, and require authentication
@@ -572,9 +588,6 @@ exports.default = {
       username: process.env.USERNAME,
       password: process.env.PASSWORD,
       cacheTtlInSeconds: 300,
-      unauthorizedResponseHeaders: {
-        accessControlAllowOrigin: '*',
-      },
     },
     lambdaConfigs: [
       {

--- a/src/cdk/create-stack.ts
+++ b/src/cdk/create-stack.ts
@@ -73,6 +73,7 @@ export function createStack(appConfig: AppConfig): void {
 
   for (const s3Config of s3Configs) {
     createS3Integration(
+      stackConfig,
       restApi,
       s3Bucket,
       s3IntegrationRole,

--- a/src/cdk/utils/create-rest-api-props.ts
+++ b/src/cdk/utils/create-rest-api-props.ts
@@ -1,4 +1,4 @@
-import {RestApiProps} from '@aws-cdk/aws-apigateway';
+import {Cors, RestApiProps} from '@aws-cdk/aws-apigateway';
 import {Stack} from '@aws-cdk/core';
 import {StackConfig} from '../../types';
 import {createDomainNameOptions} from './create-domain-name-options';
@@ -9,7 +9,11 @@ export function createRestApiProps(
   stackConfig: StackConfig,
   stack: Stack
 ): RestApiProps {
-  const {binaryMediaTypes, minimumCompressionSizeInBytes} = stackConfig;
+  const {
+    binaryMediaTypes,
+    minimumCompressionSizeInBytes,
+    enableCors,
+  } = stackConfig;
 
   return {
     restApiName: resourceName,
@@ -17,5 +21,11 @@ export function createRestApiProps(
     binaryMediaTypes,
     minimumCompressionSize: minimumCompressionSizeInBytes,
     deployOptions: createStageOptions(stackConfig),
+    defaultCorsPreflightOptions: enableCors
+      ? {
+          allowOrigins: Cors.ALL_ORIGINS,
+          allowCredentials: true,
+        }
+      : undefined,
   };
 }

--- a/src/cdk/utils/create-s3-integration-responses.ts
+++ b/src/cdk/utils/create-s3-integration-responses.ts
@@ -1,7 +1,8 @@
 import {IntegrationResponse} from '@aws-cdk/aws-apigateway';
-import {S3Config} from '../../types';
+import {S3Config, StackConfig} from '../../types';
 
 export function createS3IntegrationResponses(
+  stackConfig: StackConfig,
   s3Config: S3Config
 ): IntegrationResponse[] {
   const s3IntegrationResponseParameters: Record<string, string> = {
@@ -9,16 +10,16 @@ export function createS3IntegrationResponses(
       'integration.response.header.Content-Type',
   };
 
+  if (stackConfig.enableCors) {
+    s3IntegrationResponseParameters[
+      'method.response.header.Access-Control-Allow-Origin'
+    ] = "'*'";
+  }
+
   const {responseHeaders} = s3Config;
 
   if (responseHeaders) {
-    const {accessControlAllowOrigin, cacheControl} = responseHeaders;
-
-    if (accessControlAllowOrigin) {
-      s3IntegrationResponseParameters[
-        'method.response.header.Access-Control-Allow-Origin'
-      ] = `'${accessControlAllowOrigin}'`;
-    }
+    const {cacheControl} = responseHeaders;
 
     if (cacheControl) {
       s3IntegrationResponseParameters[

--- a/src/cdk/utils/create-s3-integration.ts
+++ b/src/cdk/utils/create-s3-integration.ts
@@ -7,11 +7,12 @@ import {
 import {Role} from '@aws-cdk/aws-iam';
 import {Bucket} from '@aws-cdk/aws-s3';
 import * as path from 'path';
-import {S3Config} from '../../types';
+import {S3Config, StackConfig} from '../../types';
 import {createS3IntegrationResponses} from './create-s3-integration-responses';
 import {createS3MethodResponses} from './create-s3-method-responses';
 
 export function createS3Integration(
+  stackConfig: StackConfig,
   restApi: RestApi,
   s3Bucket: Bucket,
   s3IntegrationRole: Role,
@@ -41,7 +42,7 @@ export function createS3Integration(
     integrationHttpMethod: 'GET',
     options: {
       credentialsRole: s3IntegrationRole,
-      integrationResponses: createS3IntegrationResponses(s3Config),
+      integrationResponses: createS3IntegrationResponses(stackConfig, s3Config),
       requestParameters:
         type === 'folder'
           ? {'integration.request.path.file': 'method.request.path.file'}
@@ -61,7 +62,7 @@ export function createS3Integration(
       ? AuthorizationType.CUSTOM
       : AuthorizationType.NONE,
     authorizer: authenticationRequired ? authorizer : undefined,
-    methodResponses: createS3MethodResponses(s3Config),
+    methodResponses: createS3MethodResponses(stackConfig, s3Config),
     requestParameters: {'method.request.path.file': type === 'folder'},
   });
 }

--- a/src/cdk/utils/create-s3-method-responses.ts
+++ b/src/cdk/utils/create-s3-method-responses.ts
@@ -1,21 +1,24 @@
 import {MethodResponse} from '@aws-cdk/aws-apigateway';
-import {S3Config} from '../../types';
+import {S3Config, StackConfig} from '../../types';
 
-export function createS3MethodResponses(s3Config: S3Config): MethodResponse[] {
+export function createS3MethodResponses(
+  stackConfig: StackConfig,
+  s3Config: S3Config
+): MethodResponse[] {
   const s3MethodResponseParameters: Record<string, boolean> = {
     'method.response.header.Content-Type': true,
   };
 
+  if (stackConfig.enableCors) {
+    s3MethodResponseParameters[
+      'method.response.header.Access-Control-Allow-Origin'
+    ] = true;
+  }
+
   const {responseHeaders} = s3Config;
 
   if (responseHeaders) {
-    const {accessControlAllowOrigin, cacheControl} = responseHeaders;
-
-    if (accessControlAllowOrigin) {
-      s3MethodResponseParameters[
-        'method.response.header.Access-Control-Allow-Origin'
-      ] = true;
-    }
+    const {cacheControl} = responseHeaders;
 
     if (cacheControl) {
       s3MethodResponseParameters['method.response.header.Cache-Control'] = true;

--- a/src/cdk/utils/create-unauthorized-gateway-response.ts
+++ b/src/cdk/utils/create-unauthorized-gateway-response.ts
@@ -15,16 +15,9 @@ export function createUnauthorizedGatewayResponse(
     'gatewayresponse.header.WWW-Authenticate': "'Basic'",
   };
 
-  const {unauthorizedResponseHeaders} = stackConfig.basicAuthenticationConfig;
-
-  if (unauthorizedResponseHeaders) {
-    const {accessControlAllowOrigin} = unauthorizedResponseHeaders;
-
-    if (accessControlAllowOrigin) {
-      responseParameters[
-        'gatewayresponse.header.Access-Control-Allow-Origin'
-      ] = `'${accessControlAllowOrigin}'`;
-    }
+  if (stackConfig.enableCors) {
+    responseParameters['gatewayresponse.header.Access-Control-Allow-Origin'] =
+      "'*'";
   }
 
   // We need to use a low-level construct here that should be replaced when

--- a/src/express/start-dev-server.ts
+++ b/src/express/start-dev-server.ts
@@ -26,11 +26,14 @@ function startDevServer(argv: unknown): void {
 
   const {port, cache, verbose} = argv;
 
+  const stackConfig = loadAppConfig().createStackConfig(port);
+
   const {
     minimumCompressionSizeInBytes,
     lambdaConfigs = [],
     s3Configs = [],
-  } = loadAppConfig().createStackConfig(port);
+    enableCors,
+  } = stackConfig;
 
   if (!verbose) {
     suppressLambdaResultLogging();
@@ -45,12 +48,12 @@ function startDevServer(argv: unknown): void {
   }
 
   for (const lambdaConfig of lambdaConfigs) {
-    serveLocalLambda(app, lambdaConfig, Boolean(cache));
+    serveLocalLambda(app, lambdaConfig, {useCache: cache});
   }
 
   // ['/foo/bar', '/', '/foo'] => ['/foo/bar', '/foo', '/']
   for (const s3Config of [...s3Configs].sort().reverse()) {
-    serveLocalS3(app, s3Config);
+    serveLocalS3(app, s3Config, {enableCors});
   }
 
   app.listen(port, () => {

--- a/src/express/utils/create-lambda-request-handler.ts
+++ b/src/express/utils/create-lambda-request-handler.ts
@@ -4,9 +4,13 @@ import * as lambdaLocal from 'lambda-local';
 import {LambdaConfig} from '../../types';
 import {getRequestHeaders} from './get-request-headers';
 
+export interface LambdaRequestHandlerOptions {
+  readonly useCache?: boolean;
+}
+
 export function createLambdaRequestHandler(
   lambdaConfig: LambdaConfig,
-  useCache: boolean
+  options: LambdaRequestHandlerOptions
 ): express.RequestHandler {
   const cachedResults = new Map<string, APIGatewayProxyResult>();
 
@@ -42,7 +46,7 @@ export function createLambdaRequestHandler(
 
       const {headers, statusCode, body} = result;
 
-      if (useCache && cachingEnabled && statusCode === 200) {
+      if (options.useCache && cachingEnabled && statusCode === 200) {
         cachedResults.set(req.url, result);
       }
 

--- a/src/express/utils/serve-local-lambda.ts
+++ b/src/express/utils/serve-local-lambda.ts
@@ -3,10 +3,14 @@ import {LambdaConfig} from '../../types';
 import {createLambdaRequestHandler} from './create-lambda-request-handler';
 import {getRouterMatcher} from './get-router-matcher';
 
+export interface LocalLambdaOptions {
+  readonly useCache?: boolean;
+}
+
 export function serveLocalLambda(
   app: express.Express,
   lambdaConfig: LambdaConfig,
-  useCache: boolean
+  options: LocalLambdaOptions
 ): void {
   const {httpMethod, publicPath} = lambdaConfig;
 
@@ -14,6 +18,6 @@ export function serveLocalLambda(
 
   getRouterMatcher(app, httpMethod)(
     normalizedPublicPath,
-    createLambdaRequestHandler(lambdaConfig, useCache)
+    createLambdaRequestHandler(lambdaConfig, options)
   );
 }

--- a/src/express/utils/serve-local-s3.ts
+++ b/src/express/utils/serve-local-s3.ts
@@ -2,14 +2,20 @@ import express from 'express';
 import * as path from 'path';
 import {S3Config} from '../../types';
 
-export function serveLocalS3(app: express.Express, s3Config: S3Config): void {
-  const {type, publicPath, localPath, responseHeaders = {}} = s3Config;
+export interface LocalS3Options {
+  readonly enableCors?: boolean;
+}
+
+export function serveLocalS3(
+  app: express.Express,
+  s3Config: S3Config,
+  options: LocalS3Options
+): void {
+  const {type, publicPath, localPath} = s3Config;
 
   const setHeaders = (res: express.Response): void => {
-    const {accessControlAllowOrigin} = responseHeaders;
-
-    if (accessControlAllowOrigin) {
-      res.setHeader('Access-Control-Allow-Origin', accessControlAllowOrigin);
+    if (options.enableCors) {
+      res.setHeader('Access-Control-Allow-Origin', '*');
     }
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,7 +63,6 @@ export interface LambdaConfig {
 }
 
 export interface S3ResponseHeaders {
-  readonly accessControlAllowOrigin?: string;
   readonly cacheControl?: string;
 }
 
@@ -78,21 +77,10 @@ export interface S3Config {
   readonly authenticationRequired?: boolean;
 }
 
-export interface UnauthorizedResponseHeaders {
-  /**
-   * Note: When an API with basic authentication is accessed cross-origin, it is
-   * important to define the origins that are allowed to access this API, even
-   * for the unauthorized response. Otherwise browsers will not be able display
-   * the dialog that prompts the credentials from the user.
-   */
-  readonly accessControlAllowOrigin?: string;
-}
-
 export interface BasicAuthenticationConfig {
   readonly username: string;
   readonly password: string;
   readonly cacheTtlInSeconds?: number;
-  readonly unauthorizedResponseHeaders?: UnauthorizedResponseHeaders;
 }
 
 export interface StackConfig {
@@ -102,6 +90,12 @@ export interface StackConfig {
   readonly lambdaConfigs?: LambdaConfig[];
   readonly s3Configs?: S3Config[];
   readonly basicAuthenticationConfig?: BasicAuthenticationConfig;
+
+  /**
+   * Note: Additionally, Lambda handlers must explicitly set any required CORS
+   * headers like `Access-Control-Allow-Origin` on their response.
+   */
+  readonly enableCors?: boolean;
 }
 
 export interface AppConfig {


### PR DESCRIPTION
BREAKING CHANGE: `basicAuthenticationConfig.unauthorizedResponseHeaders` and `s3Configs[].responseHeaders.accessControlAllowOrigin` have been removed. Use `enableCors` instead.