### PR TITLE
Add support for redeployment of the API Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ Commands:
   aws-simple list [options]      List all deployed stacks
   aws-simple tag [options]       Tag a deployed stack
   aws-simple clean-up [options]  Clean up old deployed stacks
-  aws-simple redeploy            Redeploy the API Gateway
+  aws-simple redeploy [options]  Redeploy the API Gateway
 
 Options:
   --version   Show version number                                      [boolean]
@@ -761,7 +761,7 @@ Examples:
 ### Redeploy The API Gateway
 
 ```
-aws-simple redeploy
+aws-simple redeploy [options]
 
 Redeploy the API Gateway
 

--- a/README.md
+++ b/README.md
@@ -621,6 +621,12 @@ exports.default = {
 
 _Note: Basic authentication is not handled by the local DEV server._
 
+### Troubleshooting
+
+[Some changes](https://docs.aws.amazon.com/apigateway/latest/developerguide/updating-api.html)
+to an existing stack require a redeployment of the API Gateway. So if changes to
+a stack do not work, the `aws-simple redeploy` command might help.
+
 ## CLI Usage
 
 ```
@@ -633,6 +639,7 @@ Commands:
   aws-simple list [options]      List all deployed stacks
   aws-simple tag [options]       Tag a deployed stack
   aws-simple clean-up [options]  Clean up old deployed stacks
+  aws-simple redeploy            Redeploy the API Gateway
 
 Options:
   --version   Show version number                                      [boolean]
@@ -749,6 +756,21 @@ Options:
 Examples:
   npx aws-simple clean-up
   npx aws-simple clean-up --min-age 14 --exclude release prerelease --yes
+```
+
+### Redeploy The API Gateway
+
+```
+aws-simple redeploy
+
+Redeploy the API Gateway
+
+Options:
+  --version   Show version number                                      [boolean]
+  -h, --help  Show help                                                [boolean]
+
+Examples:
+  npx aws-simple redeploy
 ```
 
 ## Development

--- a/src/cdk/create-stack.ts
+++ b/src/cdk/create-stack.ts
@@ -29,6 +29,13 @@ export function createStack(appConfig: AppConfig): void {
     createRestApiProps(`${appName} ${appVersion}`, stackConfig, stack)
   );
 
+  const restApiIdOutput = new CfnOutput(stack, 'RestApiIdOutput', {
+    value: restApi.restApiId,
+    exportName: createUniqueExportName(stack.stackName, 'RestApiId'),
+  });
+
+  restApiIdOutput.node.addDependency(restApi);
+
   const restApiUrlOutput = new CfnOutput(stack, 'RestApiUrlOutput', {
     value: restApi.url,
     exportName: createUniqueExportName(stack.stackName, 'RestApiUrl'),

--- a/src/components/redeploy-command.tsx
+++ b/src/components/redeploy-command.tsx
@@ -1,0 +1,56 @@
+import {AppContext, Color} from 'ink';
+import React from 'react';
+import {Argv} from 'yargs';
+import {AppConfigContext} from '../contexts/app-config-context';
+import {ClientConfigContext} from '../contexts/client-config-context';
+import {findStack} from '../sdk/find-stack';
+import {redeployApiGateway} from '../sdk/redeploy-api-gateway';
+import {Spinner} from './spinner';
+
+export interface RedeployCommandProps {
+  readonly argv: {readonly _: string[]};
+}
+
+interface TagArgv {
+  readonly _: ['redeploy'];
+}
+
+function isRedeployArgv(argv: {readonly _: string[]}): argv is TagArgv {
+  return argv._[0] === 'redeploy';
+}
+
+export const RedeployCommand = (
+  props: RedeployCommandProps
+): JSX.Element | null => {
+  if (!isRedeployArgv(props.argv)) {
+    return null;
+  }
+
+  const {exit} = React.useContext(AppContext);
+  const appConfig = React.useContext(AppConfigContext);
+  const clientConfig = React.useContext(ClientConfigContext);
+  const [completed, setCompleted] = React.useState(false);
+
+  React.useEffect(() => {
+    (async () => {
+      const stack = await findStack(appConfig, clientConfig);
+
+      await redeployApiGateway(clientConfig, stack);
+
+      setCompleted(true);
+    })().catch(exit);
+  }, []);
+
+  return completed ? (
+    <Color green>
+      The redeployment of the API Gateway was completed successfully.
+    </Color>
+  ) : (
+    <Spinner>The redeployment of the API Gateway is in progress.</Spinner>
+  );
+};
+
+RedeployCommand.describe = (argv: Argv) =>
+  argv.command('redeploy', 'Redeploy the API Gateway', (commandArgv) =>
+    commandArgv.example('npx $0 redeploy', '')
+  );

--- a/src/components/redeploy-command.tsx
+++ b/src/components/redeploy-command.tsx
@@ -51,6 +51,8 @@ export const RedeployCommand = (
 };
 
 RedeployCommand.describe = (argv: Argv) =>
-  argv.command('redeploy', 'Redeploy the API Gateway', (commandArgv) =>
-    commandArgv.example('npx $0 redeploy', '')
+  argv.command(
+    'redeploy [options]',
+    'Redeploy the API Gateway',
+    (commandArgv) => commandArgv.example('npx $0 redeploy', '')
   );

--- a/src/components/ui.tsx
+++ b/src/components/ui.tsx
@@ -5,6 +5,7 @@ import {ClientConfigContext} from '../contexts/client-config-context';
 import {AppConfig} from '../types';
 import {AppInfo} from './app-info';
 import {ListCommand} from './list-command';
+import {RedeployCommand} from './redeploy-command';
 import {TagCommand} from './tag-command';
 
 export interface UiProps {
@@ -20,6 +21,7 @@ export const Ui = ({appConfig, clientConfig, argv}: UiProps): JSX.Element => (
       <ClientConfigContext.Provider value={clientConfig}>
         <ListCommand argv={argv} />
         <TagCommand argv={argv} />
+        <RedeployCommand argv={argv} />
       </ClientConfigContext.Provider>
     </AppConfigContext.Provider>
   </>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import {create} from './commands/create';
 import {start} from './commands/start';
 import {upload} from './commands/upload';
 import {ListCommand} from './components/list-command';
+import {RedeployCommand} from './components/redeploy-command';
 import {TagCommand} from './components/tag-command';
 import {Ui} from './components/ui';
 import {createClientConfig} from './sdk/create-client-config';
@@ -22,6 +23,7 @@ import {loadAppConfig} from './utils/load-app-config';
   const {description} = require('../package.json');
 
   const argv = compose(
+    RedeployCommand.describe,
     cleanUp.describe,
     TagCommand.describe,
     ListCommand.describe,

--- a/src/sdk/find-stack-output.ts
+++ b/src/sdk/find-stack-output.ts
@@ -4,11 +4,6 @@ import {
   createUniqueExportName,
 } from '../utils/create-unique-export-name';
 
-export interface StackOutputs {
-  readonly restApiUrl: string;
-  readonly s3BucketName: string;
-}
-
 export function findStackOutput(
   stack: CloudFormation.Stack,
   exportName: ExportName

--- a/src/sdk/redeploy-api-gateway.ts
+++ b/src/sdk/redeploy-api-gateway.ts
@@ -1,0 +1,29 @@
+import {APIGateway, CloudFormation} from 'aws-sdk';
+import {findStackOutput} from './find-stack-output';
+
+const stageName = 'prod';
+
+/**
+ * https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-deployments.html
+ */
+export async function redeployApiGateway(
+  clientConfig: CloudFormation.ClientConfiguration,
+  stack: CloudFormation.Stack
+): Promise<void> {
+  const restApiId = findStackOutput(stack, 'RestApiId');
+  const apiGateway = new APIGateway(clientConfig);
+
+  const deployment = await apiGateway
+    .createDeployment({restApiId, stageName})
+    .promise();
+
+  await apiGateway
+    .updateStage({
+      restApiId,
+      stageName,
+      patchOperations: [
+        {op: 'replace', path: '/deploymentId', value: deployment.id},
+      ],
+    })
+    .promise();
+}

--- a/src/sdk/redeploy-api-gateway.ts
+++ b/src/sdk/redeploy-api-gateway.ts
@@ -14,7 +14,11 @@ export async function redeployApiGateway(
   const apiGateway = new APIGateway(clientConfig);
 
   const deployment = await apiGateway
-    .createDeployment({restApiId, stageName})
+    .createDeployment({
+      restApiId,
+      stageName,
+      description: 'Triggered by the aws-simple redeploy command',
+    })
     .promise();
 
   await apiGateway

--- a/src/utils/create-unique-export-name.ts
+++ b/src/utils/create-unique-export-name.ts
@@ -1,6 +1,6 @@
 import {createShortHash} from './create-short-hash';
 
-export type ExportName = 'RestApiUrl' | 'S3BucketName';
+export type ExportName = 'RestApiId' | 'RestApiUrl' | 'S3BucketName';
 
 export function createUniqueExportName(
   stackName: string,

--- a/update-readme.js
+++ b/update-readme.js
@@ -41,6 +41,7 @@ async function replaceCommandUsage(readmeText, commandName) {
   updatedReadmeText = await replaceCommandUsage(updatedReadmeText, 'list');
   updatedReadmeText = await replaceCommandUsage(updatedReadmeText, 'tag');
   updatedReadmeText = await replaceCommandUsage(updatedReadmeText, 'clean-up');
+  updatedReadmeText = await replaceCommandUsage(updatedReadmeText, 'redeploy');
 
   if (process.env.GITHUB_ACTION && updatedReadmeText !== readmeText) {
     throw new Error('The README is not up to date.');


### PR DESCRIPTION
@unstubbable I have implemented the `redeploy` command as discussed. Currently I did not have a usecase for testing. Do you have one to confirm that it works?