### PR TITLE
Check Lambda file names for valid characters

### DIFF
--- a/src/cdk/utils/create-lambda-integration.ts
+++ b/src/cdk/utils/create-lambda-integration.ts
@@ -9,6 +9,7 @@ import {Duration, Stack} from '@aws-cdk/core';
 import * as path from 'path';
 import {LambdaConfig} from '../../types';
 import {createShortHash} from '../../utils/create-short-hash';
+import {getLambdaModuleName} from '../../utils/get-lambda-module-name';
 
 export function createLambdaIntegration(
   stack: Stack,
@@ -48,10 +49,7 @@ export function createLambdaIntegration(
         description,
         runtime: Runtime.NODEJS_10_X,
         code: Code.fromAsset(path.dirname(localPath)),
-        handler: `${path.basename(
-          localPath,
-          path.extname(localPath)
-        )}.${handler}`,
+        handler: `${getLambdaModuleName(localPath)}.${handler}`,
         timeout: Duration.seconds(
           timeoutInSeconds > 28 ? 28 : timeoutInSeconds
         ),

--- a/src/express/utils/create-lambda-request-handler.ts
+++ b/src/express/utils/create-lambda-request-handler.ts
@@ -2,6 +2,7 @@ import {APIGatewayProxyResult} from 'aws-lambda';
 import express from 'express';
 import * as lambdaLocal from 'lambda-local';
 import {LambdaConfig} from '../../types';
+import {getLambdaModuleName as checkLambdaModuleName} from '../../utils/get-lambda-module-name';
 import {getRequestHeaders} from './get-request-headers';
 import {logInfo} from './log-info';
 
@@ -15,6 +16,8 @@ export function createLambdaRequestHandler(
     timeoutInSeconds = 28,
     environment,
   } = lambdaConfig;
+
+  checkLambdaModuleName(localPath);
 
   return async (req, res) => {
     try {

--- a/src/utils/get-lambda-module-name.test.ts
+++ b/src/utils/get-lambda-module-name.test.ts
@@ -1,0 +1,18 @@
+import {getLambdaModuleName} from './get-lambda-module-name';
+
+describe('getLambdaModuleName()', () => {
+  it('returns the file name without file extension', () => {
+    expect(getLambdaModuleName('index.js')).toBe('index');
+    expect(getLambdaModuleName('ABCabc.js')).toBe('ABCabc');
+  });
+
+  it('checks the file name for valid characters', () => {
+    const expectedError = new Error(
+      'The Lambda file name (without file extension) must match the following pattern: /^[A-Za-z]+$/'
+    );
+
+    expect(() => getLambdaModuleName('.js')).toThrow(expectedError);
+    expect(() => getLambdaModuleName('index.bundle.js')).toThrow(expectedError);
+    expect(() => getLambdaModuleName('index-bundle.js')).toThrow(expectedError);
+  });
+});

--- a/src/utils/get-lambda-module-name.test.ts
+++ b/src/utils/get-lambda-module-name.test.ts
@@ -3,6 +3,7 @@ import {getLambdaModuleName} from './get-lambda-module-name';
 describe('getLambdaModuleName()', () => {
   it('returns the file name without file extension', () => {
     expect(getLambdaModuleName('index.js')).toBe('index');
+    expect(getLambdaModuleName('foo/index.js')).toBe('index');
     expect(getLambdaModuleName('ABCabc.js')).toBe('ABCabc');
   });
 
@@ -12,6 +13,7 @@ describe('getLambdaModuleName()', () => {
     );
 
     expect(() => getLambdaModuleName('.js')).toThrow(expectedError);
+    expect(() => getLambdaModuleName('foo/.js')).toThrow(expectedError);
     expect(() => getLambdaModuleName('index.bundle.js')).toThrow(expectedError);
     expect(() => getLambdaModuleName('index-bundle.js')).toThrow(expectedError);
   });

--- a/src/utils/get-lambda-module-name.ts
+++ b/src/utils/get-lambda-module-name.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+
+export function getLambdaModuleName(localPath: string): string {
+  const lambdaModuleName = path.basename(localPath, path.extname(localPath));
+  const regExp = /^[A-Za-z]+$/;
+
+  if (!regExp.test(lambdaModuleName)) {
+    throw new Error(
+      `The Lambda file name (without file extension) must match the following pattern: ${regExp}`
+    );
+  }
+
+  return lambdaModuleName;
+}


### PR DESCRIPTION
For example the Lambda file name `favicon.bundle.js` leads to the following AWS runtime error `Error: Cannot find module 'favicon'`