### PR TITLE
Make lookup of authorization header value case insensitive

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,5 +6,8 @@ module.exports = {
   coverageThreshold: {
     global: {branches: 100, functions: 100, lines: 100, statements: 100},
   },
+  coveragePathIgnorePatterns: [
+    'src/cdk/utils/basic-authorizer-handler/index.ts',
+  ],
   testMatch: ['**/src/**/*.test.ts'],
 };

--- a/src/cdk/utils/basic-authorizer-handler/index.test.ts
+++ b/src/cdk/utils/basic-authorizer-handler/index.test.ts
@@ -1,0 +1,15 @@
+import {getAuthHeaderValue} from '.';
+
+describe('getAuthHeaderValue()', () => {
+  it('returns authorization header value', () => {
+    expect(getAuthHeaderValue({authorization: 'Basic 123'})).toBe('Basic 123');
+    expect(getAuthHeaderValue({Authorization: 'Basic 456'})).toBe('Basic 456');
+    expect(getAuthHeaderValue({AUTHORIZATION: 'Basic 789'})).toBe('Basic 789');
+  });
+
+  it('returns undefined', () => {
+    expect(getAuthHeaderValue(undefined)).toBeUndefined();
+    expect(getAuthHeaderValue({})).toBeUndefined();
+    expect(getAuthHeaderValue({auth: 'foo'})).toBeUndefined();
+  });
+});

--- a/src/cdk/utils/basic-authorizer-handler/index.ts
+++ b/src/cdk/utils/basic-authorizer-handler/index.ts
@@ -39,10 +39,26 @@ function createAllowPolicy(
   };
 }
 
+function getHeaderValue(
+  headers: Record<string, string> = {},
+  name: string
+): string | undefined {
+  const searchedHeaderName = name.toLowerCase();
+  return Object.entries(headers).find(
+    ([headerName]) => headerName.toLowerCase() === searchedHeaderName
+  )?.[1];
+}
+
+export function getAuthHeaderValue(
+  headers: Record<string, string> = {}
+): string | undefined {
+  return getHeaderValue(headers, 'authorization');
+}
+
 export const handler: CustomAuthorizerHandler = (event, _context, callback) => {
   if (!process.env.USERNAME) {
     callback(new Error('USERNAME is not defined.'));
-  } else if (isValidBasicAuthHeader(event.headers?.authorization)) {
+  } else if (isValidBasicAuthHeader(getAuthHeaderValue(event.headers))) {
     callback(null, createAllowPolicy(process.env.USERNAME, event.methodArn));
   } else {
     callback('Unauthorized');


### PR DESCRIPTION
some setups pass the basic auth header with first letter in upper case, so also check for this value