### PR TITLE
Block public access to S3 Bucket

### DIFF
--- a/src/cdk/create-stack.ts
+++ b/src/cdk/create-stack.ts
@@ -5,7 +5,7 @@ import {
   Role,
   ServicePrincipal,
 } from '@aws-cdk/aws-iam';
-import {Bucket, BucketEncryption} from '@aws-cdk/aws-s3';
+import {BlockPublicAccess, Bucket, BucketEncryption} from '@aws-cdk/aws-s3';
 import {App, CfnOutput, Stack} from '@aws-cdk/core';
 import {AppConfig} from '../types';
 import {createUniqueExportName} from '../utils/create-unique-export-name';
@@ -47,6 +47,7 @@ export function createStack(appConfig: AppConfig): void {
 
   const s3Bucket = new Bucket(stack, 'S3Bucket', {
     publicReadAccess: false,
+    blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
     encryption: BucketEncryption.S3_MANAGED,
   });
 


### PR DESCRIPTION
This sets the `blockPublicAccess` setting, which is recommended by AWS,
and usally required by IT security departments. Since `publicReadAccess`
was already disabled, the public access was effectively already blocked
via ACLs. Therefore this change has no practical impact on the stacks
that are deployed with aws-simple. S3 ressources are still only
accessed through the API gateway, and the public access of those
ressources can be restricted by requiring an authentication, if needed.
