### PR TITLE
The TTL for alias records can now be configured using `CustomDomain.aliasRecordTtlInSeconds`

### DIFF
--- a/src/cdk/utils/create-a-record.ts
+++ b/src/cdk/utils/create-a-record.ts
@@ -1,7 +1,7 @@
 import {RestApi} from '@aws-cdk/aws-apigateway';
 import {ARecord, HostedZone, RecordTarget} from '@aws-cdk/aws-route53';
 import {ApiGateway} from '@aws-cdk/aws-route53-targets';
-import {Stack} from '@aws-cdk/core';
+import {Duration, Stack} from '@aws-cdk/core';
 import {StackConfig} from '../../types';
 
 export function createARecord(
@@ -15,7 +15,12 @@ export function createARecord(
     return;
   }
 
-  const {hostedZoneId, hostedZoneName, aliasRecordName} = customDomainConfig;
+  const {
+    hostedZoneId,
+    hostedZoneName,
+    aliasRecordName,
+    aliasRecordTtlInSeconds,
+  } = customDomainConfig;
 
   const aRecord = new ARecord(stack, 'ARecord', {
     zone: HostedZone.fromHostedZoneAttributes(stack, 'HostedZone', {
@@ -24,6 +29,10 @@ export function createARecord(
     }),
     recordName: aliasRecordName,
     target: RecordTarget.fromAlias(new ApiGateway(restApi)),
+    ttl:
+      aliasRecordTtlInSeconds !== undefined
+        ? Duration.seconds(aliasRecordTtlInSeconds)
+        : undefined,
   });
 
   aRecord.node.addDependency(restApi);

--- a/src/new-types.ts
+++ b/src/new-types.ts
@@ -12,6 +12,7 @@ export interface CustomDomain {
   readonly hostedZoneId: string;
   readonly hostedZoneName: string;
   readonly aliasRecordName?: string;
+  readonly aliasRecordTtlInSeconds?: number;
 }
 
 export interface Authentication {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface CustomDomainConfig {
   readonly hostedZoneId: string;
   readonly hostedZoneName: string;
   readonly aliasRecordName?: string;
+  readonly aliasRecordTtlInSeconds?: number;
 }
 
 export type LambdaHttpMethod =


### PR DESCRIPTION
~~Stacks which are configured with the old configuration format have a default TTL value of 30 minutes (CDK default), otherwise 5 minutes.~~