### PR TITLE
Use Node 14 runtime for lambdas

### DIFF
--- a/src/cdk/utils/create-basic-authorizer.ts
+++ b/src/cdk/utils/create-basic-authorizer.ts
@@ -23,7 +23,7 @@ export function createBasicAuthorizer(
   return new RequestAuthorizer(stack, 'BasicAuthorizer', {
     handler: new Lambda(stack, 'AuthorizerLambda', {
       description: `${appName} Authorizer Lambda ${appVersion}`,
-      runtime: Runtime.NODEJS_12_X,
+      runtime: Runtime.NODEJS_14_X,
       code: Code.fromAsset(
         path.dirname(require.resolve('./basic-authorizer-handler'))
       ),

--- a/src/cdk/utils/create-lambda-integration.ts
+++ b/src/cdk/utils/create-lambda-integration.ts
@@ -47,7 +47,7 @@ export function createLambdaIntegration(
     new LambdaIntegration(
       new Lambda(stack, `Lambda${httpMethod}${createShortHash(publicPath)}`, {
         description,
-        runtime: Runtime.NODEJS_12_X,
+        runtime: Runtime.NODEJS_14_X,
         code: Code.fromAsset(path.dirname(localPath)),
         handler: `${getLambdaModuleName(localPath)}.${handler}`,
         timeout: Duration.seconds(


### PR DESCRIPTION
We should ship this as a new major version, as we did for the Node 12 update as well. For the release notes:
**Potentially breaking:** Use Node 14 runtime for lambdas