### PR TITLE
Do not fail when trying to delete empty S3 buckets

### DIFF
--- a/src/sdk/delete-s3-bucket.ts
+++ b/src/sdk/delete-s3-bucket.ts
@@ -11,12 +11,17 @@ export async function deleteS3Bucket(
     .promise();
 
   const objectIdentifiers = Contents.filter(
-    ({Key}) => typeof Key === 'string'
-  ).map(({Key}) => ({Key} as S3.ObjectIdentifier));
+    (object): object is S3.ObjectIdentifier => typeof object.Key === 'string'
+  ).map(({Key}) => ({Key}));
 
-  await s3
-    .deleteObjects({Bucket: s3BucketName, Delete: {Objects: objectIdentifiers}})
-    .promise();
+  if (objectIdentifiers.length > 0) {
+    await s3
+      .deleteObjects({
+        Bucket: s3BucketName,
+        Delete: {Objects: objectIdentifiers},
+      })
+      .promise();
+  }
 
   await s3.deleteBucket({Bucket: s3BucketName}).promise();
 }


### PR DESCRIPTION
If an S3 bucket is empty, `deleteObjects` will fail with the following error:

```
MalformedXML: The XML you provided was not well-formed or did not validate against our published schema
```

In this case we need to skip `deleteObjects` and only call `deleteBucket`.
