### PR TITLE
Dev server: specify response encoding for a base64 encoded body

### DIFF
--- a/src/cdk/utils/create-basic-authorizer.ts
+++ b/src/cdk/utils/create-basic-authorizer.ts
@@ -14,11 +14,8 @@ export function createBasicAuthorizer(
     return undefined;
   }
 
-  const {
-    username,
-    password,
-    cacheTtlInSeconds,
-  } = stackConfig.basicAuthenticationConfig;
+  const {username, password, cacheTtlInSeconds} =
+    stackConfig.basicAuthenticationConfig;
 
   return new RequestAuthorizer(stack, 'BasicAuthorizer', {
     handler: new Lambda(stack, 'AuthorizerLambda', {

--- a/src/cdk/utils/create-lambda-integration.ts
+++ b/src/cdk/utils/create-lambda-integration.ts
@@ -73,9 +73,8 @@ export function createLambdaIntegration(
       authorizer: authenticationRequired ? authorizer : undefined,
       requestParameters: Object.keys(acceptedParameters).reduce(
         (requestParameters, parameterName) => {
-          requestParameters[
-            `method.request.querystring.${parameterName}`
-          ] = Boolean(acceptedParameters[parameterName]!.required);
+          requestParameters[`method.request.querystring.${parameterName}`] =
+            Boolean(acceptedParameters[parameterName]!.required);
 
           return requestParameters;
         },

--- a/src/cdk/utils/create-rest-api-props.ts
+++ b/src/cdk/utils/create-rest-api-props.ts
@@ -9,11 +9,8 @@ export function createRestApiProps(
   stackConfig: StackConfig,
   stack: Stack
 ): RestApiProps {
-  const {
-    binaryMediaTypes,
-    minimumCompressionSizeInBytes,
-    enableCors,
-  } = stackConfig;
+  const {binaryMediaTypes, minimumCompressionSizeInBytes, enableCors} =
+    stackConfig;
 
   return {
     restApiName: resourceName,

--- a/src/cdk/utils/create-s3-method-responses.ts
+++ b/src/cdk/utils/create-s3-method-responses.ts
@@ -20,9 +20,8 @@ export function createS3MethodResponses(
     const {cacheControl} = responseHeaders;
 
     if (cacheControl) {
-      status200ResponseParameters[
-        'method.response.header.Cache-Control'
-      ] = true;
+      status200ResponseParameters['method.response.header.Cache-Control'] =
+        true;
     }
   }
 

--- a/src/cdk/utils/create-stage-options.ts
+++ b/src/cdk/utils/create-stage-options.ts
@@ -54,9 +54,8 @@ export function createStageOptions(stackConfig: StackConfig): StageOptions {
       cacheClusterEnabled = true;
     }
 
-    methodOptions[createMethodPath(lambdaConfig)] = createMethodOption(
-      lambdaConfig
-    );
+    methodOptions[createMethodPath(lambdaConfig)] =
+      createMethodOption(lambdaConfig);
   }
 
   for (const s3Config of s3Configs) {

--- a/src/contexts/client-config-context.ts
+++ b/src/contexts/client-config-context.ts
@@ -1,6 +1,5 @@
 import {CloudFormation} from 'aws-sdk';
 import React from 'react';
 
-export const ClientConfigContext = React.createContext<CloudFormation.ClientConfiguration>(
-  {}
-);
+export const ClientConfigContext =
+  React.createContext<CloudFormation.ClientConfiguration>({});

--- a/src/express/utils/create-lambda-request-handler.ts
+++ b/src/express/utils/create-lambda-request-handler.ts
@@ -52,7 +52,7 @@ export function createLambdaRequestHandler(
           },
         }));
 
-      const {headers, statusCode, body} = result;
+      const {headers, statusCode, body, isBase64Encoded} = result;
 
       if (!cachedResult && statusCode === 200) {
         lambdaCache?.set(req.url, result);
@@ -68,7 +68,13 @@ export function createLambdaRequestHandler(
         logInfo(`DEV server cache hit for Lambda request: ${req.url}`);
       }
 
-      res.status(statusCode).send(body);
+      res.status(statusCode);
+
+      if (isBase64Encoded) {
+        res.end(body, 'base64');
+      } else {
+        res.send(body);
+      }
     } catch (error) {
       res.status(500).send(error);
     }


### PR DESCRIPTION
Without this a base64 encoded response can not be decoded by the browser:

```
net::ERR_CONTENT_DECODING_FAILED 200 (OK)
```