### PR TITLE
Fix cache invalidation for catchall routes

### DIFF
--- a/src/express/start-dev-server.ts
+++ b/src/express/start-dev-server.ts
@@ -58,7 +58,7 @@ export async function startDevServer(init: DevServerInit): Promise<void> {
         lambdaCaches.set(routeConfig, new Map());
 
         logInfo(
-          `Initialized DEV server cache for Lambda: ${routeConfig.localPath}`
+          `Initialized DEV server cache for Lambda: ${routeConfig.publicPath} -> ${routeConfig.localPath}`
         );
       }
 
@@ -72,16 +72,18 @@ export async function startDevServer(init: DevServerInit): Promise<void> {
     logInfo(`Started DEV server: http://localhost:${port}`);
 
     const handleLocalPathChanges = (changedLocalPath: string) => {
-      const changedLambdaConfig = lambdaConfigs.find(
+      const changedLambdaConfigs = lambdaConfigs.filter(
         ({localPath}) => localPath === changedLocalPath
       );
 
-      if (lambdaCaches && changedLambdaConfig?.cachingEnabled) {
-        lambdaCaches.set(changedLambdaConfig, new Map());
+      for (const changedLambdaConfig of changedLambdaConfigs) {
+        if (lambdaCaches && changedLambdaConfig?.cachingEnabled) {
+          lambdaCaches.set(changedLambdaConfig, new Map());
 
-        logInfo(
-          `Invalidated DEV server cache for Lambda: ${changedLambdaConfig.localPath}`
-        );
+          logInfo(
+            `Invalidated DEV server cache for Lambda: ${changedLambdaConfig.publicPath} -> ${changedLambdaConfig.localPath}`
+          );
+        }
       }
 
       removeAllRoutes(app);
@@ -99,7 +101,7 @@ export async function startDevServer(init: DevServerInit): Promise<void> {
 
       logInfo(
         `Reregistered DEV server routes because of changed ${
-          changedLambdaConfig ? 'Lambda' : 'S3'
+          changedLambdaConfigs.length ? 'Lambda' : 'S3'
         } file: ${changedLocalPath}`
       );
     };


### PR DESCRIPTION
Previously, only the first route targeting a local path was selected for
cache invalidation. However, catchall routes are registered twice with
different public paths and separate caches. This caused stale caches for
catchall routes.

This change invalidates all caches related to a changed local path and
mentions the public path in the log messages to avoid seemingly
duplicate cache invalidation messages.