### PR TITLE
Add optional local path dependencies for DEV server

### DIFF
--- a/src/express/start-dev-server.ts
+++ b/src/express/start-dev-server.ts
@@ -73,7 +73,19 @@ export async function startDevServer(init: DevServerInit): Promise<void> {
 
     const handleLocalPathChanges = (changedLocalPath: string) => {
       const changedLambdaConfigs = lambdaConfigs.filter(
-        ({localPath}) => localPath === changedLocalPath
+        ({localPath, devServer, publicPath}) =>
+          localPath === changedLocalPath ||
+          devServer?.localPathDependencies?.some((localPathDependency) => {
+            if (localPathDependency === changedLocalPath) {
+              logInfo(
+                `Changed local DEV path dependency detected for Lambda: ${publicPath} depends on ${localPathDependency}`
+              );
+
+              return true;
+            }
+
+            return false;
+          })
       );
 
       for (const changedLambdaConfig of changedLambdaConfigs) {

--- a/src/new-types.ts
+++ b/src/new-types.ts
@@ -38,6 +38,14 @@ export interface CommonRoute {
   readonly enableCors?: boolean;
 }
 
+export interface DevServerOptions {
+  /**
+   * Local path dependencies for a Lambda function that should be included in
+   * the files watched for cache invalidation.
+   */
+  readonly localPathDependencies?: string[];
+}
+
 export interface FunctionRoute extends CommonRoute {
   readonly kind: 'function';
   readonly filename: string;
@@ -75,6 +83,7 @@ export interface FunctionRoute extends CommonRoute {
   readonly loggingLevel?: FunctionLoggingLevel;
   readonly parameters?: Readonly<Record<string, FunctionParameterOptions>>;
   readonly environment?: Readonly<Record<string, string>>;
+  readonly devServer?: DevServerOptions;
 }
 
 export type FunctionMethod =

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import {DevServerOptions} from './new-types';
+
 export * from './new-types';
 
 export interface CustomDomainConfig {
@@ -63,6 +65,7 @@ export interface LambdaConfig {
   readonly acceptedParameters?: LambdaAcceptedParameters;
   readonly environment?: LambdaEnvironment;
   readonly authenticationRequired?: boolean;
+  readonly devServer?: DevServerOptions;
 }
 
 export interface S3ResponseHeaders {

--- a/src/utils/translate-app-config.ts
+++ b/src/utils/translate-app-config.ts
@@ -54,6 +54,7 @@ export function translateAppConfig(app: App): AppConfig {
             ),
             environment: route.environment,
             authenticationRequired: route.enableAuthentication,
+            devServer: route.devServer,
           };
 
           lambdaConfigs.push(lambdaConfig);


### PR DESCRIPTION
This change enables specifying additional local paths that should be
considered for Lambda cache invalidation when using the DEV server.

The AWS lambda configuration is not affected.