### PR TITLE
When loading the config file throws an error it should be logged

### DIFF
--- a/src/utils/load-app-config.ts
+++ b/src/utils/load-app-config.ts
@@ -31,8 +31,10 @@ export function loadAppConfig(): AppConfig {
     const absoluteConfigFilename = path.resolve('aws-simple.config.js');
 
     appConfig = require(absoluteConfigFilename).default;
-  } catch {
-    throw new Error('The aws-simple config file cannot be loaded.');
+  } catch (error) {
+    console.error('The aws-simple config file cannot be loaded.');
+
+    throw error;
   }
 
   if (isAppConfig(appConfig)) {


### PR DESCRIPTION
This allows users to identify the error they have in their config file.
The stack of the aws-simple code that loads the config file is not
really needed/helpful. Therefore we re-throw the original error, and log
a message beforehand.
