### PR TITLE
Add delete-stack command

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,14 +471,15 @@ a stack do not work, the `aws-simple redeploy` command might help.
 Usage: aws-simple <command> [options]
 
 Commands:
-  aws-simple create [options]       Create a stack using the CDK
-  aws-simple upload [options]       Upload files to S3
-  aws-simple start [options]        Start a local DEV server
-  aws-simple list [options]         List all deployed stacks
-  aws-simple tag [options]          Tag a deployed stack
-  aws-simple clean-up [options]     Clean up old deployed stacks
-  aws-simple redeploy [options]     Redeploy the API Gateway
-  aws-simple flush-cache [options]  Flush the cache of the API Gateway
+  aws-simple delete-stack [options]  Deletes the stack
+  aws-simple create [options]        Create a stack using the CDK
+  aws-simple upload [options]        Upload files to S3
+  aws-simple start [options]         Start a local DEV server
+  aws-simple list [options]          List all deployed stacks
+  aws-simple tag [options]           Tag a deployed stack
+  aws-simple clean-up [options]      Clean up old deployed stacks
+  aws-simple redeploy [options]      Redeploy the API Gateway
+  aws-simple flush-cache [options]   Flush the cache of the API Gateway
 
 Options:
       --version  Show version number                                   [boolean]
@@ -596,6 +597,23 @@ Options:
 Examples:
   npx aws-simple clean-up
   npx aws-simple clean-up --min-age 14 --exclude release prerelease --yes
+```
+
+### Delete a single stack
+
+```
+aws-simple delete-stack [options]
+
+Deletes the stack and remove all attached AWS resources
+
+Options:
+      --version  Show version number                                   [boolean]
+  -h, --help     Show help                                             [boolean]
+      --yes      The confirmation message will automatically be answered with
+                 yes                                  [boolean] [default: false]
+
+Examples:
+  npx index.js delete-stack --yes
 ```
 
 ### Redeploy the API Gateway

--- a/src/commands/delete-stack.ts
+++ b/src/commands/delete-stack.ts
@@ -1,0 +1,129 @@
+import type {CloudFormation} from 'aws-sdk';
+import chalk from 'chalk';
+import Listr from 'listr';
+import pRetry from 'p-retry';
+import prompts from 'prompts';
+import type {Argv} from 'yargs';
+import {deleteS3Bucket} from '../sdk/delete-s3-bucket';
+import {deleteStack as deleteCloudFormationStack} from '../sdk/delete-stack';
+import {findStackOutput} from '../sdk/find-stack-output';
+import {findStacks} from '../sdk/find-stacks';
+import type {AppConfig} from '../types';
+import {isObject} from '../utils/is-object';
+import { createStackName } from '../utils/stack-name';
+
+interface DeleteStackArgv {
+  readonly _: ['delete-stack'];
+  readonly yes: boolean;
+}
+
+function isDeleteStackArgv(argv: {
+  readonly _: unknown[];
+}): argv is DeleteStackArgv {
+  return argv._[0] === `delete-stack`;
+}
+
+export async function deleteStack(
+  appConfig: AppConfig,
+  clientConfig: CloudFormation.ClientConfiguration,
+  argv: {readonly _: unknown[]},
+): Promise<void> {
+  if (!isDeleteStackArgv(argv)) {
+    return;
+  }
+
+  const stackName = createStackName(appConfig);
+  const stacks = await findStacks(appConfig, clientConfig);
+  const stackToDelete = stacks.find((stack) => stack.StackName === stackName);
+
+  if (!stackToDelete) {
+    console.info(`No stack found with name ${stackName}.`);
+
+    return;
+  }
+
+  if (!argv.yes) {
+    console.info(`Found stack ${stackToDelete.StackName} with status: ${stackToDelete.StackStatus}`);
+
+    const {deleteConfirmation} = await prompts({
+      type: `confirm`,
+      name: `deleteConfirmation`,
+      message: chalk.bold(
+        chalk.red(`The stack ${stackToDelete.StackName} will be deleted. Continue?`),
+      ),
+    });
+
+    if (!deleteConfirmation) {
+      return;
+    }
+  }
+
+  const listrTasks: Listr.ListrTask[] = [];
+
+  listrTasks.push({
+    title: `Deleting stack ${stackToDelete.StackName} and associated S3 bucket`,
+    task: () =>
+      new Listr(
+        [
+          {
+            title: `Deleting stack`,
+            task: async (_, listrSubTask) =>
+              pRetry(
+                async () =>
+                  deleteCloudFormationStack(clientConfig, stackToDelete),
+                {
+                  retries: 10,
+                  onFailedAttempt: ({attemptNumber, retriesLeft}) => {
+                    listrSubTask.title = `Attempt ${attemptNumber} to delete the stack failed. There are ${retriesLeft} retries left.`;
+                  },
+                },
+              ),
+          },
+          {
+            title: `Deleting S3 bucket`,
+            task: async (_, listrSubTask) => {
+              let s3BucketName: string;
+
+              try {
+                s3BucketName = findStackOutput(stackToDelete, `S3BucketName`);
+              } catch (error) {
+                listrSubTask.skip(
+                  error instanceof Error ? error.message : `No bucket name.`,
+                );
+
+                return;
+              }
+
+              try {
+                await deleteS3Bucket(clientConfig, s3BucketName);
+              } catch (error) {
+                if (isObject(error) && error.code === `NoSuchBucket`) {
+                  listrSubTask.skip(
+                    error instanceof Error ? error.message : `No such bucket.`,
+                  );
+                } else {
+                  throw error;
+                }
+              }
+            },
+          },
+        ],
+        {exitOnError: true},
+      ),
+  });
+
+  await new Listr(listrTasks, {concurrent: true, exitOnError: false}).run();
+}
+
+deleteStack.describe = (argv: Argv) =>
+  argv.command(`delete-stack [options]`, `Deletes the stack and remove all attached AWS resources`, (commandArgv) =>
+    commandArgv
+      .describe(
+        `yes`,
+        `The confirmation message will automatically be answered with yes`,
+      )
+      .boolean(`yes`)
+      .default(`yes`, false)
+
+      .example(`npx $0 delete-stack --yes`, ``),
+  );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,6 +8,7 @@ import signalExit from 'signal-exit';
 import yargs from 'yargs';
 import {cleanUp} from './commands/clean-up';
 import {create} from './commands/create';
+import {deleteStack} from './commands/delete-stack';
 import {flushCache} from './commands/flush-cache';
 import {start} from './commands/start';
 import {upload} from './commands/upload';
@@ -31,6 +32,7 @@ import {loadAppConfig} from './utils/load-app-config';
     start.describe,
     upload.describe,
     create.describe,
+    deleteStack.describe
   )(
     yargs
       .usage(`Usage: $0 <command> [options]`)
@@ -61,6 +63,7 @@ import {loadAppConfig} from './utils/load-app-config';
   await upload(appConfig, clientConfig, argv);
   await cleanUp(appConfig, clientConfig, argv);
   await flushCache(appConfig, clientConfig, argv);
+  await deleteStack(appConfig, clientConfig, argv);
 
   await exitPromise;
 })().catch((error) => {


### PR DESCRIPTION
We need to delete a single stack to clean up pull request deployments. I realized later that I've used the old ui stuff and additionally, I duplicated a lot of code. If you instruct me where to put the shared code (with the `clean-up` command), I'm happy to move it there.