### PR TITLE
feat: support apollo server

### DIFF
--- a/src/express/start-dev-server.ts
+++ b/src/express/start-dev-server.ts
@@ -48,6 +48,7 @@ export async function startDevServer(init: DevServerInit): Promise<void> {
   const app = express();
 
   app.use(express.text());
+  app.use(express.json());
 
   const port = await getPort({port: requestedPort});
   const stackConfig = appConfig.createStackConfig(port);

--- a/src/express/utils/get-querystring-parameters.ts
+++ b/src/express/utils/get-querystring-parameters.ts
@@ -1,0 +1,32 @@
+import type {
+  APIGatewayProxyEventMultiValueQueryStringParameters,
+  APIGatewayProxyEventQueryStringParameters,
+} from 'aws-lambda';
+import type {Request} from 'express';
+import type {ParamsDictionary} from 'express-serve-static-core';
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((element) => typeof element === `string`);
+
+export const getQueryStringParameters = (
+  query: Request<ParamsDictionary>['query'],
+): {
+  multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters;
+  queryStringParameters: APIGatewayProxyEventQueryStringParameters;
+} => {
+  const queryStringParameters: APIGatewayProxyEventQueryStringParameters = {};
+  const multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters =
+    {};
+
+  for (const [key, value] of Object.entries(query)) {
+    if (typeof value === `string`) {
+      multiValueQueryStringParameters[key] = [value];
+      queryStringParameters[key] = value;
+    } else if (isStringArray(value)) {
+      multiValueQueryStringParameters[key] = value;
+      queryStringParameters[key] = value[value.length - 1];
+    }
+  }
+
+  return {multiValueQueryStringParameters, queryStringParameters};
+};

--- a/src/express/utils/get-request-headers.ts
+++ b/src/express/utils/get-request-headers.ts
@@ -8,10 +8,10 @@ export function getRequestHeaders(
   const multiValueHeaders: Record<string, string[]> = {};
 
   for (const [key, value] of Object.entries(req.headers)) {
-    if (Array.isArray(value)) {
-      multiValueHeaders[key] = value;
-    } else if (typeof value === `string`) {
-      headers[key] = value;
+    if (value) {
+      const values = [value].flat();
+      multiValueHeaders[key] = values;
+      headers[key] = values[values.length - 1]!;
     }
   }
 

--- a/src/lambda-local.d.ts
+++ b/src/lambda-local.d.ts
@@ -6,8 +6,10 @@ declare module 'lambda-local' {
   } from 'aws-lambda';
   import type {Logger} from 'winston';
 
+  type DeepPartial<T extends {}> = {[k in keyof T]?: DeepPartial<T[k]>};
+
   export interface LambdaLocalExecuteOptions {
-    readonly event?: Partial<APIGatewayProxyEvent>;
+    readonly event?: DeepPartial<APIGatewayProxyEvent>;
     readonly environment?: {readonly [key: string]: string};
     readonly lambdaPath?: string;
     readonly lambdaFunc?: ProxyHandler;


### PR DESCRIPTION
To let the dev-server from aws-simple work with Apollo-Server-Lambda we've added:

-  The json parser `express.json()`. Without this, express will discard the body of an request with content/mime-type `application/json`
- The `requestContext`object to the `lambdaLocal` execution, as this is eventually evaluated inside the apollo server.

Additionally, we have changed the way `multiValueHeaders` are treated: now, we copy all normal headers to the `multiValueHeaders` so that `multiValueHeaders` always containing all header values. If the `multiValueHeaders` are not falsy, the apollo server only reads the `multiValueHeaders` ignoring of the normal headers.