### PR TITLE
Prepend function names with the method

### DIFF
--- a/src/cdk/utils/create-lambda-integration.ts
+++ b/src/cdk/utils/create-lambda-integration.ts
@@ -49,6 +49,7 @@ export function createLambdaIntegration(
   const functionName = getFunctionName(
     getFullyQualifiedDomainName(stackConfig),
     publicPath,
+    httpMethod,
   );
 
   const lambdaFunction = new aws_lambda.Function(stack, functionName, {

--- a/src/utils/get-function-name.test.ts
+++ b/src/utils/get-function-name.test.ts
@@ -2,14 +2,16 @@ import {getFunctionName} from './get-function-name';
 
 describe(`getFunctionName()`, () => {
   it(`generates a unique function name`, () => {
-    expect(getFunctionName(`example.com`, `/`)).toBe(`example_com-9a06d5b`);
-
-    expect(getFunctionName(`example.com`, `/foo/bar`)).toBe(
-      `example_com-foo_bar-747bc1b`,
+    expect(getFunctionName(`example.com`, `/`, `GET`)).toBe(
+      `GET-example_com-9a06d5b`,
     );
 
-    expect(getFunctionName(`test.example.com`, `/foo/bar`)).toBe(
-      `test_example_com-foo_bar-747bc1b`,
+    expect(getFunctionName(`example.com`, `/foo/bar`, `POST`)).toBe(
+      `POST-example_com-foo_bar-747bc1b`,
+    );
+
+    expect(getFunctionName(`test.example.com`, `/foo/bar`, `DELETE`)).toBe(
+      `DELETE-test_example_com-foo_bar-747bc1b`,
     );
   });
 
@@ -19,7 +21,7 @@ describe(`getFunctionName()`, () => {
 
     for (let i = 0; i < 17; pathname += `/${i++}`) {}
 
-    const functionName = getFunctionName(domainName, pathname);
+    const functionName = getFunctionName(domainName, pathname, `DELETE`);
     const hash = `e7f243b`;
 
     expect(pathname).toHaveLength(41);
@@ -27,7 +29,7 @@ describe(`getFunctionName()`, () => {
     expect(functionName).toHaveLength(64);
 
     expect(functionName).toBe(
-      `test_example_com-0_1_2_3_4_5_6_7_8_9_10_11_12_13_14_15_1-${hash}`,
+      `DELETE-test_example_com-0_1_2_3_4_5_6_7_8_9_10_11_12_13_-${hash}`,
     );
   });
 });

--- a/src/utils/get-function-name.ts
+++ b/src/utils/get-function-name.ts
@@ -1,3 +1,4 @@
+import type {FunctionMethod} from '../new-types';
 import {createShortHash} from './create-short-hash';
 
 export interface FunctionNameOptions {
@@ -5,12 +6,16 @@ export interface FunctionNameOptions {
   readonly pathname: string;
 }
 
-export function getFunctionName(domainName: string, pathname: string): string {
+export function getFunctionName(
+  domainName: string,
+  pathname: string,
+  method: FunctionMethod,
+): string {
   const normalizedDomainName = domainName.replace(/[^\w]/g, `_`);
   const normalizedPathname = pathname.replace(`/`, ``).replace(/[^\w]/g, `_`);
 
-  return `${(normalizedPathname
+  return `${method}-${(normalizedPathname
     ? [normalizedDomainName, normalizedPathname].join(`-`)
     : normalizedDomainName
-  ).slice(0, 56)}-${createShortHash(pathname)}`;
+  ).slice(0, 56 - (method.length + 1))}-${createShortHash(pathname)}`;
 }


### PR DESCRIPTION
This guarantees that the logical ID of the function (which is generated by the CDK based on the function name) starts with a letter. The logical ID must not start with a number, which might be the case if a commit hash is used as `appVersion`.