### PR TITLE
Print termination protection status in list command

### DIFF
--- a/src/list-command.ts
+++ b/src/list-command.ts
@@ -1,5 +1,6 @@
 import type yargs from 'yargs';
 import {readStackConfig} from './read-stack-config';
+import {findStack} from './sdk/find-stack';
 import {findStacks} from './sdk/find-stacks';
 import {getFormattedAgeInDays} from './utils/get-formatted-age-in-days';
 import {print} from './utils/print';
@@ -101,6 +102,17 @@ export async function listCommand(args: ListCommandArgs): Promise<void> {
       type: `entry`,
       key: `Updated`,
       value: getFormattedAgeInDays(stack.LastUpdatedTime!),
+    });
+
+    // For some reason `stack.EnableTerminationProtection` is always
+    // `undefined`. Describing a single stack instead, does return the correct
+    // value (true or false) for `EnableTerminationProtection`.
+    const {EnableTerminationProtection} = await findStack(stack.StackName!);
+
+    print.listItem(1, {
+      type: `entry`,
+      key: `Termination protection`,
+      value: EnableTerminationProtection ? `Enabled` : `Disabled`,
     });
 
     if (stack.Tags && stack.Tags?.length > 0) {

--- a/src/sdk/find-stack.ts
+++ b/src/sdk/find-stack.ts
@@ -1,10 +1,17 @@
 import type {Stack} from '@aws-sdk/client-cloudformation';
-import {findStacks} from './find-stacks';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from '@aws-sdk/client-cloudformation';
 
 export async function findStack(stackName: string): Promise<Stack> {
-  const stack = (await findStacks()).find(
-    ({StackName}) => StackName === stackName,
+  const client = new CloudFormationClient({});
+
+  const {Stacks} = await client.send(
+    new DescribeStacksCommand({StackName: stackName}),
   );
+
+  const stack = Stacks?.[0];
 
   if (!stack) {
     throw new Error(`The stack cannot be found: ${stackName}`);


### PR DESCRIPTION
The wording is aligned with the aws developer console:

<img width="209" alt="Screenshot 2022-02-17 at 11 27 04" src="https://user-images.githubusercontent.com/761683/154457034-1d152bc5-8706-4f53-9650-5267b981dc3f.png">

