### PR TITLE
Fix CORS configuration for Lambda functions

### DIFF
--- a/src/cdk/add-cors-preflight.ts
+++ b/src/cdk/add-cors-preflight.ts
@@ -1,0 +1,56 @@
+import {aws_apigateway} from 'aws-cdk-lib';
+
+export interface AddCorsPreflightOptions {
+  readonly authenticationEnabled?: boolean;
+}
+
+/**
+ * Because we are defining "\*\/\*" as `binaryMediaTypes` for the REST API, we
+ * need to explicitly convert the request body to text, to avoid a configuration
+ * error for CORS preflight requests. Since this `contentHandling` can't be
+ * defined with `resource.addCorsPreflight({...})`, we need to define the
+ * OPTIONS method manually instead, using the defaults that the aws-cdk would
+ * also select when using `resource.addCorsPreflight()`.
+ */
+export function addCorsPreflight(
+  resource: aws_apigateway.Resource,
+  options: AddCorsPreflightOptions,
+): void {
+  const methodResponse: aws_apigateway.MethodResponse = {
+    statusCode: `204`,
+    responseParameters: {
+      'method.response.header.Access-Control-Allow-Headers': true,
+      'method.response.header.Access-Control-Allow-Methods': true,
+      'method.response.header.Access-Control-Allow-Origin': true,
+    },
+  };
+
+  const integrationResponse: aws_apigateway.IntegrationResponse = {
+    statusCode: `204`,
+    responseParameters: {
+      'method.response.header.Access-Control-Allow-Headers': `'${aws_apigateway.Cors.DEFAULT_HEADERS}'`,
+      'method.response.header.Access-Control-Allow-Methods': `'${aws_apigateway.Cors.ALL_METHODS}'`,
+      'method.response.header.Access-Control-Allow-Origin': `'${aws_apigateway.Cors.ALL_ORIGINS}'`,
+    },
+  };
+
+  if (options.authenticationEnabled) {
+    methodResponse.responseParameters![
+      `method.response.header.Access-Control-Allow-Credentials`
+    ] = true;
+
+    integrationResponse.responseParameters![
+      `method.response.header.Access-Control-Allow-Credentials`
+    ] = `'true'`;
+  }
+
+  resource.addMethod(
+    `OPTIONS`,
+    new aws_apigateway.MockIntegration({
+      requestTemplates: {'application/json': `{ statusCode: 200 }`},
+      contentHandling: aws_apigateway.ContentHandling.CONVERT_TO_TEXT,
+      integrationResponses: [integrationResponse],
+    }),
+    {methodResponses: [methodResponse]},
+  );
+}

--- a/src/cdk/add-lambda-resource.ts
+++ b/src/cdk/add-lambda-resource.ts
@@ -1,6 +1,7 @@
 import type {LambdaRoute, StackConfig} from '../read-stack-config.js';
 import type {Stack, aws_lambda} from 'aws-cdk-lib';
 
+import {addCorsPreflight} from './add-cors-preflight.js';
 import {createLambdaFunction} from './create-lambda-function.js';
 import {aws_apigateway} from 'aws-cdk-lib';
 
@@ -35,11 +36,6 @@ export function addLambdaResource(
     cacheKeyParameters,
   });
 
-  const corsOptions: aws_apigateway.CorsOptions = {
-    allowOrigins: aws_apigateway.Cors.ALL_ORIGINS,
-    allowCredentials: authenticationEnabled,
-  };
-
   const methodOptions: aws_apigateway.MethodOptions = {
     authorizationType: authenticationEnabled
       ? aws_apigateway.AuthorizationType.CUSTOM
@@ -57,7 +53,7 @@ export function addLambdaResource(
   const resource = restApi.root.resourceForPath(publicPath.replace(`/*`, `/`));
 
   if (corsEnabled) {
-    resource.addCorsPreflight(corsOptions);
+    addCorsPreflight(resource, {authenticationEnabled});
   }
 
   resource.addMethod(httpMethod, integration, methodOptions);
@@ -68,7 +64,7 @@ export function addLambdaResource(
     );
 
     if (corsEnabled) {
-      proxyResource.addCorsPreflight(corsOptions);
+      addCorsPreflight(proxyResource, {authenticationEnabled});
     }
 
     proxyResource.addMethod(httpMethod, integration, methodOptions);


### PR DESCRIPTION
Because we are defining `*/*` as `binaryMediaTypes` for the REST API, we need to explicitly convert the request body to text, to avoid a configuration error for CORS preflight requests. Since this `contentHandling` can't be defined with
`resource.addCorsPreflight({...})`, we need to define the `OPTIONS` method manually instead, using the defaults that the `aws-cdk` would also select when using `resource.addCorsPreflight()`.

Inspiration for the fix: https://stackoverflow.com/a/69666161

fixes #167