### PR TITLE
Share a single lambda service role across all lambda functions

### DIFF
--- a/src/cdk/add-s3-resource.ts
+++ b/src/cdk/add-s3-resource.ts
@@ -5,13 +5,20 @@ import {addCorsPreflight} from './add-cors-preflight.js';
 import {aws_apigateway} from 'aws-cdk-lib';
 import {join} from 'path';
 
+export interface S3ResourceConstructDependencies {
+  readonly bucket: aws_s3.IBucket;
+  readonly bucketReadRole: aws_iam.IRole;
+  readonly requestAuthorizer: aws_apigateway.IAuthorizer | undefined;
+  readonly restApi: aws_apigateway.RestApiBase;
+}
+
 export function addS3Resource(
   route: S3Route,
-  restApi: aws_apigateway.RestApiBase,
-  bucket: aws_s3.IBucket,
-  bucketReadRole: aws_iam.IRole,
-  requestAuthorizer: aws_apigateway.IAuthorizer | undefined,
+  constructDependencies: S3ResourceConstructDependencies,
 ): void {
+  const {bucket, bucketReadRole, requestAuthorizer, restApi} =
+    constructDependencies;
+
   const {type, publicPath, path, authenticationEnabled, corsEnabled} = route;
 
   if (authenticationEnabled && !requestAuthorizer) {

--- a/src/cdk/create-lambda-function.ts
+++ b/src/cdk/create-lambda-function.ts
@@ -1,5 +1,5 @@
 import type {LambdaRoute, StackConfig} from '../parse-stack-config.js';
-import type {Stack} from 'aws-cdk-lib';
+import type {Stack, aws_iam} from 'aws-cdk-lib';
 
 import {getDomainName} from '../utils/get-domain-name.js';
 import {getHash} from '../utils/get-hash.js';
@@ -7,13 +7,20 @@ import {getNormalizedName} from '../utils/get-normalized-name.js';
 import {Duration, aws_lambda, aws_logs} from 'aws-cdk-lib';
 import {basename, dirname, extname, join} from 'path';
 
+export interface LambdaFunctionConstructDependencies {
+  readonly lambdaServiceRole: aws_iam.IRole;
+  readonly stack: Stack;
+}
+
 const maxTimeoutInSeconds = 28;
 
 export function createLambdaFunction(
   stackConfig: StackConfig,
   route: LambdaRoute,
-  stack: Stack,
+  constructDependencies: LambdaFunctionConstructDependencies,
 ): aws_lambda.FunctionBase {
+  const {lambdaServiceRole, stack} = constructDependencies;
+
   const {
     httpMethod,
     publicPath,
@@ -60,6 +67,7 @@ export function createLambdaFunction(
       runtime: aws_lambda.Runtime.NODEJS_18_X,
       tracing: aws_lambda.Tracing.PASS_THROUGH,
       logRetention: aws_logs.RetentionDays.TWO_WEEKS,
+      role: lambdaServiceRole,
     },
   );
 }

--- a/src/cdk/create-lambda-service-role.ts
+++ b/src/cdk/create-lambda-service-role.ts
@@ -1,0 +1,15 @@
+import type {Stack} from 'aws-cdk-lib';
+
+import {aws_iam} from 'aws-cdk-lib';
+
+export function createLambdaServiceRole(stack: Stack): aws_iam.IRole {
+  return new aws_iam.Role(stack, `LambdaServiceRole`, {
+    assumedBy: new aws_iam.ServicePrincipal(`lambda.amazonaws.com`),
+    managedPolicies: [
+      aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
+        `service-role/AWSLambdaBasicExecutionRole`,
+      ),
+      aws_iam.ManagedPolicy.fromAwsManagedPolicyName(`AWSXrayWriteOnlyAccess`),
+    ],
+  });
+}


### PR DESCRIPTION
This reduces the chance of reaching the AWS service quota limit of 1000 IAM roles per account when deploying many stacks with multiple lambdas per stack.