### PR TITLE
fix cleanup missing tags

### DIFF
--- a/src/sdk/get-tags-for-role.ts
+++ b/src/sdk/get-tags-for-role.ts
@@ -1,0 +1,19 @@
+import type { ListRoleTagsCommandOutput, Tag } from '@aws-sdk/client-iam';
+
+import { IAMClient, ListRoleTagsCommand } from '@aws-sdk/client-iam';
+
+export async function getTagsForRole(RoleName?: string): Promise<Tag[]> {
+  const tags: Tag[] = [];
+  const client = new IAMClient({});
+  let output: ListRoleTagsCommandOutput | undefined;
+
+  do {
+    output = await client.send(new ListRoleTagsCommand({ RoleName, Marker: output?.Marker }));
+
+    if (output.Tags) {
+      tags.push(...output.Tags);
+    }
+  } while (output.Marker);
+
+  return tags;
+}


### PR DESCRIPTION
Fix for previous PR: The tags are not part of roles fetched by ListRolesCommand so script to filter was not working. Tags have to be fetched by another function which can be called only one role a time. This should fix the issue.