### PR TITLE
feat: add Node.js 24.x lambda runtime support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,23 +64,23 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.242",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.242.tgz",
-      "integrity": "sha512-4c1bAy2ISzcdKXYS1k4HYZsNrgiwbiDzj36ybwFVxEWZXVAP0dimQTCaB9fxu7sWzEjw3d+eaw6Fon+QTfTIpQ==",
+      "version": "2.2.273",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.273.tgz",
+      "integrity": "sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==",
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
-      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.1.tgz",
+      "integrity": "sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==",
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "45.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-45.2.0.tgz",
-      "integrity": "sha512-5TTUkGHQ+nfuUGwKA8/Yraxb+JdNUh4np24qk/VHXmrCMq+M6HfmGWfhcg/QlHA2S5P3YIamfYHdQAB4uSNLAg==",
+      "version": "53.20.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-53.20.0.tgz",
+      "integrity": "sha512-4kLAUO+I8b4nlk1Z2P4n3Ye8UtqCiXk0kJMLUThBnyHLbdz06rwAb+qlb9WZOie7NtPluemVS243ifcBh/NVsQ==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -89,7 +89,7 @@
       "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.2"
+        "semver": "^7.7.4"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -105,7 +105,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -4159,11 +4159,12 @@
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.207.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.207.0.tgz",
-      "integrity": "sha512-DlXUeg6cK6T71jyf6UQAUquRVnG388dIsxb4IuW0Wkn+9t6z4NO39sGCs91mV2RZtPChWy+e8BRVtQx/uBdLww==",
+      "version": "2.252.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.252.0.tgz",
+      "integrity": "sha512-bRLyTtJxhVgsx2JrL2B/KYYWf+Rg0s68UgQp+VRZK0h5fXeaPqDVEJGPMr7FiOgrmYwEadjfbxsTsZKNAloAvg==",
       "bundleDependencies": [
         "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
         "case",
         "fs-extra",
         "ignore",
@@ -4178,26 +4179,47 @@
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "2.2.242",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^45.0.0",
+        "@aws-cdk/asset-awscli-v1": "2.2.273",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.1",
+        "@aws-cdk/cloud-assembly-api": "^2.2.2",
+        "@aws-cdk/cloud-assembly-schema": "^53.18.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.3.0",
+        "fs-extra": "^11.3.3",
         "ignore": "^5.3.2",
         "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
-        "minimatch": "^3.1.2",
+        "minimatch": "^10.2.3",
         "punycode": "^2.3.1",
-        "semver": "^7.7.2",
+        "semver": "^7.7.4",
         "table": "^6.9.0",
-        "yaml": "1.10.2"
+        "yaml": "1.10.3"
       },
       "engines": {
-        "node": ">= 14.15.0"
+        "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "constructs": "^10.0.0"
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.2",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "jsonschema": "~1.4.1",
+        "semver": "^7.7.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=53.15.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -4207,7 +4229,7 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.17.1",
+      "version": "8.18.0",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -4256,19 +4278,24 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
-      "version": "1.0.2",
+      "version": "4.0.4",
       "inBundle": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "5.0.5",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
@@ -4298,12 +4325,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/aws-cdk-lib/node_modules/concat-map": {
-      "version": "0.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
@@ -4317,7 +4338,7 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.6",
+      "version": "3.1.0",
       "funding": [
         {
           "type": "github",
@@ -4333,7 +4354,7 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.3.0",
+      "version": "11.3.3",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -4377,7 +4398,7 @@
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
-      "version": "6.1.0",
+      "version": "6.2.0",
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -4425,15 +4446,18 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
-      "version": "3.1.2",
+      "version": "10.2.5",
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "peer": true,
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
@@ -4455,7 +4479,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.7.2",
+      "version": "7.7.4",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -4535,7 +4559,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
-      "version": "1.10.2",
+      "version": "1.10.3",
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -4697,8 +4721,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/body-parser": {
       "version": "1.20.4",
@@ -4778,7 +4801,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5167,13 +5189,11 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
-      "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
-      "peer": true,
-      "engines": {
-        "node": ">= 16.14.0"
-      }
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.6.0.tgz",
+      "integrity": "sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -7944,7 +7964,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -8712,7 +8731,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/src/parse-stack-config.ts
+++ b/src/parse-stack-config.ts
@@ -31,7 +31,7 @@ export type LambdaRoute = Omit<z.TypeOf<typeof LambdaRouteSchema>, 'onSynthesize
 
 export type S3Route = z.TypeOf<typeof S3RouteSchema>;
 
-const LambdaRuntimeSchema = z.enum([`20.x`, `22.x`, `LATEST`]).optional();
+const LambdaRuntimeSchema = z.enum([`20.x`, `22.x`, `24.x`, `LATEST`]).optional();
 export type LambdaRuntime = z.TypeOf<typeof LambdaRuntimeSchema>;
 
 const LambdaRouteSchema = z.object({

--- a/src/utils/map-lambda-runtime.test.ts
+++ b/src/utils/map-lambda-runtime.test.ts
@@ -7,6 +7,7 @@ describe(`mapLambdaRuntime()`, () => {
     expect(mapLambdaRuntime(undefined)).toEqual(aws_lambda.Runtime.NODEJS_20_X);
     expect(mapLambdaRuntime(`20.x`)).toEqual(aws_lambda.Runtime.NODEJS_20_X);
     expect(mapLambdaRuntime(`22.x`)).toEqual(aws_lambda.Runtime.NODEJS_22_X);
+    expect(mapLambdaRuntime(`24.x`)).toEqual(aws_lambda.Runtime.NODEJS_24_X);
     expect(mapLambdaRuntime(`LATEST`)).toEqual(aws_lambda.Runtime.NODEJS_LATEST);
   });
 });

--- a/src/utils/map-lambda-runtime.ts
+++ b/src/utils/map-lambda-runtime.ts
@@ -12,6 +12,8 @@ export function mapLambdaRuntime(lambdaRuntime: LambdaRuntime): aws_lambda.Runti
       return aws_lambda.Runtime.NODEJS_20_X;
     case `22.x`:
       return aws_lambda.Runtime.NODEJS_22_X;
+    case `24.x`:
+      return aws_lambda.Runtime.NODEJS_24_X;
     case `LATEST`:
       return aws_lambda.Runtime.NODEJS_LATEST;
   }


### PR DESCRIPTION
## Summary

- Add `24.x` as a valid lambda runtime option
- Update `aws-cdk-lib` from v2.207.0 to v2.252.0 (which includes `NODEJS_24_X`)
- Add corresponding mapping and test coverage